### PR TITLE
I have fixed some bugs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,6 +218,16 @@
                 "key": "ctrl+x ctrl+f",
                 "command": "emacs.C-x_C-f",
                 "when": "editorTextFocus"
+            },
+            {
+                "key": "ctrl+/",
+                "command": "emacs.C-/",
+                "when": "editorTextFocus"
+            },
+            {
+                "key": "ctrl+g ctrl+/",
+                "command": "emacs.C-g_C-/",
+                "when": "editorTextFocus"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -224,11 +224,6 @@
                 "when": "editorTextFocus"
             },
             {
-                "key": "ctrl+g ctrl+/",
-                "command": "emacs.C-g_C-/",
-                "when": "editorTextFocus"
-            },
-            {
                 "key": "ctrl+p",
                 "command": "showPrevParameterHint",
                 "when": "editorTextFocus && parameterHintsVisible"

--- a/package.json
+++ b/package.json
@@ -216,8 +216,7 @@
             },
             {
                 "key": "ctrl+x ctrl+f",
-                "command": "emacs.C-x_C-f",
-                "when": "editorTextFocus"
+                "command": "emacs.C-x_C-f"
             },
             {
                 "key": "ctrl+/",

--- a/package.json
+++ b/package.json
@@ -205,6 +205,11 @@
                 "when": "editorTextFocus"
             },
             {
+                "key": "ctrl+x z",
+                "command": "emacs.C-x_z",
+                "when": "editorTextFocus"
+            },
+            {
                 "key": "ctrl+x ctrl+w",
                 "command": "emacs.C-x_C-w",
                 "when": "editorTextFocus"

--- a/package.json
+++ b/package.json
@@ -228,6 +228,44 @@
                 "key": "ctrl+g ctrl+/",
                 "command": "emacs.C-g_C-/",
                 "when": "editorTextFocus"
+            },
+            {
+                "key": "ctrl+p",
+                "command": "showPrevParameterHint",
+                "when": "editorTextFocus && parameterHintsVisible"
+            },
+            {
+                "key": "ctrl+n",
+                "command": "showNextParameterHint",
+                "when": "editorTextFocus && parameterHintsVisible"
+            },
+            {
+                "key": "ctrl+p",
+                "command": "selectPrevQuickFix",
+                "when": "editorFocus && quickFixWidgetVisible"
+            },
+            {
+                "key": "ctrl+n",
+                "command": "selectNextQuickFix",
+                "when": "editorFocus && quickFixWidgetVisible"
+            },
+            {
+                "key": "ctrl+p",
+                "command": "selectPrevSuggestion",
+                "when": "editorTextFocus && suggestWidgetVisible"
+            },
+            {
+                "key": "ctrl+n",
+                "command": "selectNextSuggestion",
+                "when": "editorTextFocus && suggestWidgetVisible"
+            },
+            {   "key": "ctrl+p",
+                "command": "workbench.action.quickOpenNavigatePrevious",
+                "when": "inQuickOpen"
+            },
+            {   "key": "ctrl+n",
+                "command": "workbench.action.quickOpenNavigateNext",
+                "when": "inQuickOpen"
             }
         ]
     },

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -189,7 +189,7 @@ export class Editor {
     }
     
     openFile(): void {
-        vscode.commands.executeCommand("workbench.action.files.openFile");
+        vscode.commands.executeCommand("workbench.action.files.openFileFolder");
     }
     
     deleteRight(): void {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -176,6 +176,14 @@ export class Editor {
         vscode.commands.executeCommand("editor.action.insertLineAfter");
     }
     
+    gotoBeginningOfLine(): void {
+        vscode.commands.executeCommand("cursorHome");
+    }
+
+    gotoEndOfLine(): void {
+        vscode.commands.executeCommand("cursorEnd");
+    }
+
     gotoLine(): void {
         vscode.commands.executeCommand("workbench.action.gotoLine");
     }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -208,6 +208,10 @@ export class Editor {
         vscode.commands.executeCommand("undo");
     }
     
+    redo(): void {
+        vscode.commands.executeCommand("redo");
+    }
+
     cursorUndo(): void {
         vscode.commands.executeCommand("cursorUndo");
     }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -176,14 +176,6 @@ export class Editor {
         vscode.commands.executeCommand("editor.action.insertLineAfter");
     }
     
-    gotoBeginningOfLine(): void {
-        vscode.commands.executeCommand("cursorHome");
-    }
-
-    gotoEndOfLine(): void {
-        vscode.commands.executeCommand("cursorEnd");
-    }
-
     gotoLine(): void {
         vscode.commands.executeCommand("workbench.action.gotoLine");
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ export function activate(context: vscode.ExtensionContext) {
         "C-j","C-m","C-o",
         "C-semicolon","M-semicolon",
         "C-x_h","C-x_u","C-x_C-s","C-x_C-w","C-x_C-f",
+        "C-/", "C-g_C-/",
         
         //File
         "C-x",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,7 @@ export function activate(context: vscode.ExtensionContext) {
         "C-j","C-m","C-o",
         "C-semicolon","M-semicolon",
         "C-x_h","C-x_u","C-x_C-s","C-x_C-w","C-x_C-f",
-        "C-/", "C-g_C-/",
+        "C-/", "C-x_z",
         
         //File
         "C-x",

--- a/src/motion.ts
+++ b/src/motion.ts
@@ -54,7 +54,9 @@ export class Motion implements vscode.Disposable {
     }
     
     move(line: number = null, character: number = null): Motion {
-        if (this.edit_mode === EditMode.MARK)  return this.select(line, character);
+        if (this.edit_mode === EditMode.MARK) {
+            return this.select(line, character);
+        }
         
         if (line != null && character != null) {
             this.point = new Point(line, character);
@@ -128,11 +130,13 @@ export class Motion implements vscode.Disposable {
     
     lineBegin(): Motion {
         this.point = this.point.lineBegin();
+        this.column = this.point.character;
         return this;
     }
     
     lineEnd(): Motion {
         this.point = this.point.lineEnd();
+        this.column = this.point.character;
         return this;
     }
     

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -177,6 +177,16 @@ export class Operation {
                 this.editor.undo();
                 this.editor.getStatusBar().addText(" u").clear();
                 this.editor.setCx(false);
+            },
+            "C-/": () => {
+                this.editor.undo();
+                this.editor.getStatusBar().setText("Undo").clear();
+                this.editor.setCx(false);
+            },
+            "C-g_C-/": () => {
+                this.editor.redo();
+                this.editor.getStatusBar().setText("Redo").clear();
+                this.editor.setCx(false);
             }
         };
     }

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -24,8 +24,8 @@ export class Operation {
             'C-b': () => this.editor.getMotion().left().move(),
             'C-n': () => this.editor.getMotion().down().move(),
             'C-p': () => this.editor.getMotion().up().move(),
-            'C-a': () => this.editor.gotoBeginningOfLine(),
-            'C-e': () => this.editor.gotoEndOfLine(),
+            'C-a': () => this.editor.getMotion().lineBegin().move(),
+            'C-e': () => this.editor.getMotion().lineEnd().move(),
             'M-f': () => this.editor.getMotion().rightWord().move(),
             'M-b': () => this.editor.getMotion().leftWord().move(),
             'C-v': () => {

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -182,11 +182,6 @@ export class Operation {
                 this.editor.undo();
                 this.editor.getStatusBar().setText("Undo").clear();
                 this.editor.setCx(false);
-            },
-            "C-g_C-/": () => {
-                this.editor.redo();
-                this.editor.getStatusBar().setText("Redo").clear();
-                this.editor.setCx(false);
             }
         };
     }

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -24,8 +24,8 @@ export class Operation {
             'C-b': () => this.editor.getMotion().left().move(),
             'C-n': () => this.editor.getMotion().down().move(),
             'C-p': () => this.editor.getMotion().up().move(),
-            'C-a': () => this.editor.getMotion().lineBegin().move(),
-            'C-e': () => this.editor.getMotion().lineEnd().move(),
+            'C-a': () => this.editor.gotoBeginningOfLine(),
+            'C-e': () => this.editor.gotoEndOfLine(),
             'M-f': () => this.editor.getMotion().rightWord().move(),
             'M-b': () => this.editor.getMotion().leftWord().move(),
             'C-v': () => {

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -178,6 +178,11 @@ export class Operation {
                 this.editor.getStatusBar().addText(" u").clear();
                 this.editor.setCx(false);
             },
+            "C-x_z": () => {
+                this.editor.redo();
+                this.editor.getStatusBar().addText(" z").clear();
+                this.editor.setCx(false);
+            },
             "C-/": () => {
                 this.editor.undo();
                 this.editor.getStatusBar().setText("Undo").clear();

--- a/src/point.ts
+++ b/src/point.ts
@@ -107,7 +107,6 @@ export class Point extends vscode.Position {
         return new Point(max_line, max_character);
     }
  
-    
     isFirstLine(): boolean {
         return this.line === 0;
     }
@@ -149,7 +148,6 @@ export class Point extends vscode.Position {
         return false;
     }
     
-  
     getLineLength(line_number: number = null): number {
         line_number = (line_number === null) ? vscode.window.activeTextEditor.selection.active.line : line_number;
         
@@ -159,5 +157,4 @@ export class Point extends vscode.Position {
         }
         return 0;
     }
-    
 }


### PR DESCRIPTION
1. `workbench.action.files.openFile` doesn't work anymore (I don't know why). So, I have changed to `workbench.action.files.openFileFolder` instead.
2. I found weird behaviour when using C-a and C-e. It moved the cursor but when I toggled up (C-p) or down (C-n), the cursor went back to its original character position. So, I have changed from using Motion and Point modules to vscode command instead (`cursorHome` and `cursorEnd`).
