### PR TITLE
Make ctrl-k copy the line it kills instead of just deleting it.

### DIFF
--- a/src/operation.ts
+++ b/src/operation.ts
@@ -78,10 +78,8 @@ export class Operation {
                 if (!this.editor.getMotion().getPoint().isLineEnd()) {
                     this.editor.setMarkMode();
                     this.editor.getMotion().lineEnd().move();
-                    let range = this.editor.getMarkSelection();
-                    return Editor.delete(range).then(() => {
-                        this.editor.setNormalMode();
-                    });
+                    this.editor.cut();
+                    this.editor.yank();
                 } else {
                     this.editor.setNormalMode();
                     this.editor.getStatusBar().init();


### PR DESCRIPTION
According to the documentation (and EmacsWiki), `kill` is equivalent to `cut` in emacs. So `ctrl+k` should actually cut the line, not just delete it.
