### PR TITLE
Set version number to minor release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,39 @@
+## 0.1.0
+- Fix: IntelliSense Suggestion.
+- Add C-x b.
+
+## 0.0.10 (2016-08-29)
+- Fix #18: Add Esc to step out from mark mode.
+- Add C-x C-o.
+- Fix: do not enter automatically in Mark Mode after Yanking. 
+
+## 0.0.9 (2016-07-24)
+- Add Kill-ring.
+- Alt-x show commands palette.
+
+All changes written by gizak, sammy44nts. Thanks
+
+## 0.0.7 (2016-07-14)
+- bug fix for C-k. **Thanks trezm.**
+- C-x C-f execute "workbench.action.files.openFile".
+
+Thanks sammy44nts.
+
+## 0.0.6
+- C-p and C-n can be used in other panels such as Suggestion and Hint.
+- Fix bug C-x C-f won't open file explorer.
+- Add one more undo operation C-/
+- Add redo operation C-x z
+- Fix incorrect column moving after using C-a and C-e
+
+These commands and bug fixes were coding by kpping. Thanks. :)
+
+## 0.0.5
+- Change the processing of C-u, C-h.
+- Change the processing of C-x C-f, C-x C-w, C-x C-s.
+
+## 0.0.4
+- Modify the search operation.
+
+## 0.0.3
+- Fixed a bug that occurred when you start from the command line.

--- a/README.md
+++ b/README.md
@@ -2,36 +2,6 @@
 
 This is emacs like plugin for Visual Studio Code.
 
-## Update History
-
-0.0.9 (2016-07-24)
-- Add Kill-ring
-- Alt-x show commands palette.
-All changes written by gizak, sammy44nts. Thanks
-
-0.0.7 (2016-07-14)
-- bug fix for C-k. Thanks trezm.
-- C-o and C-x C-f execute "workbench.action.files.openFile". Thanks sammy44nts.
-
-0.0.6
-- C-p and C-n can be used in other panels such as Suggestion and Hint.
-- Fix bug C-x C-f won't open file explorer.
-- Add one more undo operation C-/
-- Add redo operation C-x z
-- Fix incorrect column moving after using C-a and C-e
-
-These commands and bug fixes were coding by kpping. Thanks. :)
-
-0.0.5
-- Change the processing of C-u, C-h.
-- Change the processing of C-x C-f, C-x C-w, C-x C-s.
-
-0.0.4
-- Modify the search operation.
-
-0.0.3
-- Fixed a bug that occurred when you start from the command line.
-
 ## Operation
 Use `Shift+DEL` to cut to clipboard, the `Ctrl+C` is not overridden.
 Use `Shift+Insert` to paste from clipboard.
@@ -80,7 +50,7 @@ Use `Shift+Insert` to paste from clipboard.
 | `C-x C-o` | OK | Delete blank lines around |
 | `C-x h` | OK | Select All |
 | `C-x u` (`C-/`)| OK | Undo |
-| `C-;` | OK | Toggle line comment in and out |
+| `C-;` | △ | Toggle line comment in and out |
 | `M-;` | △ | Toggle region comment in and out |
 
 ### Other Command
@@ -100,6 +70,7 @@ Use `Shift+Insert` to paste from clipboard.
 |Command | Status | Desc |
 |--------|--------|------|
 | `C-o` | OK | Open a file |
+| `C-x b` | OK | QuickOpen a file |
 | `C-x C-f` | OK | Open a working directory |
 | `C-x C-s` | OK | Save |
 | `C-x C-w` | OK | Save as |
@@ -112,11 +83,12 @@ Use `Shift+Insert` to paste from clipboard.
 - `ctrl+d`: editor.action.addSelectionToNextFindMatch => **Use `ctrl+alt+n` instead**;
 - `ctrl+g`: workbench.action.gotoLine => **Use `alt+g g` instead**;
 - `ctrl+b`: workbench.action.toggleSidebarVisibility => **Use `ctrl+alt+space` instead**;
-- `ctrl+space`: toggleSuggestionDetails, editor.action.triggerSuggest;
+- `ctrl+space`: toggleSuggestionDetails, editor.action.triggerSuggest => **Use `ctrl+'` instead**;
 - `ctrl+x`: editor.action.clipboardCutAction => **Use `shift+delete` instead**;
 - `ctrl+v`: editor.action.clipboardPasteAction => **Use `shift+insert` instead**;
 - `ctrl+k`: editor.debug.action.showDebugHover, editor.action.trimTrailingWhitespace, editor.action.showHover, editor.action.removeCommentLine, editor.action.addCommentLine, editor.action.openDeclarationToTheSide;
 - `ctrl+y`: redo;
 - `ctrl+m`: editor.action.toggleTabFocusMode;
 - `ctrl+/`: editor.action.commentLine => **Use `ctrl+;` instead**;
+- `ctrl+p` & `ctrl+e`: workbench.action.quickOpen => **Use `ctrl+x b` instead**;
 - `ctrl+p`: workbench.action.quickOpenNavigateNext => **Use `ctrl+n` instead**.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-emacs",
     "displayName": "vscode-emacs",
     "description": "emacs like extension for vscode",
-    "version": "0.0.10",
+    "version": "0.1.0",
     "publisher": "hiro-sun",
     "homepage": "https://github.com/hiro-sun/vscode-emacs",
     "repository": {
@@ -267,6 +267,10 @@
                 "command": "editor.action.triggerSuggest",
                 "when": "editorTextFocus"
             },{
+                "key": "ctrl+'",
+                "command": "toggleSuggestionDetails",
+                "when": "editorTextFocus && suggestWidgetVisible"
+            },{
                 "key": "ctrl+shift+'",
                 "command": "editor.action.triggerParameterHints",
                 "when": "editorTextFocus"
@@ -276,6 +280,9 @@
             },{
                 "key": "ctrl+alt+space",
                 "command": "workbench.action.toggleSidebarVisibility"
+            }, {
+                "key": "ctrl+x b",
+                "command": "workbench.action.quickOpen"
             }
         ]
     },


### PR DESCRIPTION
vscode-emacs is now mature enough to use a minor release version number.

So we could use the patch number of the version number for bug fixing.
- Fix: IntelliSense Suggestion;
- Add C-x b.
