### PR TITLE
Add support for 'C-x r s' and 'C-x r i' keybindings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -276,6 +276,10 @@
             },{
                 "key": "ctrl+alt+space",
                 "command": "workbench.action.toggleSidebarVisibility"
+            },{
+                "key": "ctrl+x r",
+                "command": "emacs.C-x_r",
+                "when": "editorTextFocus"
             }
         ]
     },

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,12 +1,26 @@
 import * as vscode from 'vscode';
+import {RegisterContent, RectangleContent, RegisterKind} from './registers';
+
+enum KeybindProgressMode {
+    None,   // No current keybind is currently in progress
+    RMode,  // Rectangle and/or Register keybinding  [started by 'C-x+r'] is currently in progress
+    RModeS, // 'Save Region in register' keybinding [started by 'C-x+r+s'] is currently in progress
+    RModeI, // 'Insert Register content into buffer' keybinding [started by 'C-x+r+i'] is currently in progress
+    AMode,  // (FUTURE, TBD) Abbrev keybinding  [started by 'C-x+a'] is currently in progress
+    MacroRecordingMode  // (FUTURE, TBD) Emacs macro recording [started by 'Ctrl-x+('] is currently in progress
+};
 
 export class Editor {
     private killRing: string;
     private isKillRepeated: boolean;
+    private keybindProgressMode: KeybindProgressMode;
+    private registersStorage: { [key:string] : RegisterContent; };
 
     constructor() {
         this.killRing = '';
         this.isKillRepeated = false;
+        this.keybindProgressMode = KeybindProgressMode.None;
+        this.registersStorage = {};
         vscode.window.onDidChangeTextEditorSelection(() => {
             this.isKillRepeated = false;
         });
@@ -14,6 +28,10 @@ export class Editor {
 
     setStatusBarMessage(text: string): vscode.Disposable {
         return vscode.window.setStatusBarMessage(text, 1000);
+    }
+
+    setStatusBarPermanentMessage(text: string): vscode.Disposable {
+        return vscode.window.setStatusBarMessage(text); 
     }
 
     getSelectionRange(): vscode.Range {
@@ -183,4 +201,135 @@ export class Editor {
         });
     }
 
+    setRMode(): void {
+        this.setStatusBarPermanentMessage("C-x r");
+        this.keybindProgressMode = KeybindProgressMode.RMode; 
+        return;
+    }
+
+    onType(text: string): void {
+        let fHandled = false;
+        switch(this.keybindProgressMode)
+        {
+            case KeybindProgressMode.RMode:
+                switch (text)
+                {
+                    // Rectangles
+                    case 'r':
+                        this.setStatusBarMessage("'C-x r r' (Copy rectangle to register) is not supported.");
+                        this.keybindProgressMode = KeybindProgressMode.None;
+                        fHandled = true;
+                        break;
+
+                    case 'k':
+                        this.setStatusBarMessage("'C-x r k' (Kill rectangle) is not supported.");
+                        this.keybindProgressMode = KeybindProgressMode.None;
+                        fHandled = true;
+                        break;
+
+                    case 'y':
+                        this.setStatusBarMessage("'C-x r y' (Yank rectangle) is not supported.");
+                        this.keybindProgressMode = KeybindProgressMode.None;
+                        fHandled = true;
+                        break;
+
+                    case 'o':
+                        this.setStatusBarMessage("'C-x r o' (Open rectangle) is not supported.");
+                        this.keybindProgressMode = KeybindProgressMode.None;
+                        fHandled = true;
+                        break;
+
+                    case 'c':
+                        this.setStatusBarMessage("'C-x r c' (Blank out rectangle) is not supported.");
+                        this.keybindProgressMode = KeybindProgressMode.None;
+                        fHandled = true;
+                        break;
+
+                    case 't':
+                        this.setStatusBarMessage("'C-x r t' (prefix each line with a string) is not supported.");
+                        this.keybindProgressMode = KeybindProgressMode.None;
+                        fHandled = true;
+                        break;
+
+                    // Registers
+                    case 's':
+                        this.setStatusBarPermanentMessage("Copy to register:");
+                        this.keybindProgressMode = KeybindProgressMode.RModeS;
+                        fHandled = true;
+                        break;
+
+                    case 'i':
+                        this.setStatusBarPermanentMessage("Insert register:");
+                        this.keybindProgressMode = KeybindProgressMode.RModeI;
+                        fHandled = true;
+                        break;
+
+                    default:
+                        break;
+                }
+                break;
+
+            case KeybindProgressMode.RModeS:
+                this.setStatusBarPermanentMessage("");
+                this.SaveTextToRegister(text);
+                this.keybindProgressMode = KeybindProgressMode.None;
+                fHandled = true;
+                break;
+
+            case KeybindProgressMode.RModeI:
+                this.setStatusBarPermanentMessage("");
+                this.RestoreTextFromRegister(text);
+                this.keybindProgressMode = KeybindProgressMode.None;
+                fHandled = true;
+                break;
+
+            case KeybindProgressMode.AMode: // not supported [yet]
+            case KeybindProgressMode.MacroRecordingMode: // not supported [yet]
+            case KeybindProgressMode.None:
+            default:
+                this.keybindProgressMode = KeybindProgressMode.None;
+                this.setStatusBarPermanentMessage("");
+                break;
+        }
+
+        if (!fHandled) {
+            // default input handling: pass control to VSCode
+            vscode.commands.executeCommand('default:type', {
+                text: text
+            });
+        }
+        return;    
+    }
+
+    SaveTextToRegister(registerName: string): void {
+        if (null == registerName) {
+            return;
+        }
+        let range : vscode.Range = this.getSelectionRange();
+        if (range !== null) {
+            let selectedText = vscode.window.activeTextEditor.document.getText(range);
+            if (null !== selectedText) {
+                this.registersStorage[registerName] = RegisterContent.fromRegion(selectedText);
+            }
+        }
+        return;
+    }
+    
+    RestoreTextFromRegister(registerName: string): void {
+        vscode.commands.executeCommand("emacs.exitMarkMode"); // emulate Emacs 
+        let obj : RegisterContent = this.registersStorage[registerName];
+        if (null == obj) {
+            this.setStatusBarMessage("Register does not contain text.");
+            return;
+        }
+        if (RegisterKind.KText === obj.getRegisterKind()) {
+            const content : string | vscode.Position | RectangleContent = obj.getRegisterContent();
+            if (typeof content === 'string') {
+                vscode.window.activeTextEditor.edit(editBuilder => {
+                    editBuilder.insert(this.getSelection().active, content);
+                });
+            }
+        }  
+        return;
+    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,10 @@ export function activate(context: vscode.ExtensionContext): void {
 
             // Edit
             "C-k", "C-w", "M-w", "C-y", "C-x_C-o",
-            "C-x_u", "C-/"
+            "C-x_u", "C-/",
+
+            // R-Mode
+            "C-x_r"
         ],
         cursorMoves: string[] = [
             "cursorUp", "cursorDown", "cursorLeft", "cursorRight",
@@ -34,6 +37,14 @@ export function activate(context: vscode.ExtensionContext): void {
             })
         )
     });
+
+    // 'type' is not an "emacs." command and should be registered separately
+    context.subscriptions.push(vscode.commands.registerCommand("type", function (args) {
+		if (!vscode.window.activeTextEditor) {
+			return;
+		}
+		op.onType(args.text);        
+    }));
 
     initMarkMode(context);
 }

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -44,11 +44,18 @@ export class Operation {
             },
             'C-g': () => {
                 this.editor.setStatusBarMessage("Quit");
-            }
+            },
+            "C-x_r": () => {
+                this.editor.setRMode();
+            },
         };
     }
 
     getCommand(commandName: string): (...args: any[]) => any {
         return this.commandList[commandName];
+    }
+
+    onType(text: string): void {
+        this.editor.onType(text);
     }
 }

--- a/src/registers.ts
+++ b/src/registers.ts
@@ -1,0 +1,43 @@
+import * as vscode from 'vscode';
+
+export enum RegisterKind {
+    KText = 1,
+    KPoint = 2,
+    KRectangle = 3
+};
+
+export class RectangleContent { // TODO: move it to rectangle.ts eventually.
+    // TBD
+};
+
+export class RegisterContent {
+    private kind : RegisterKind;
+    private content :   string              // stores region/text
+                        | vscode.Position   // stores position 
+                        | RectangleContent; // stores rectangle
+                        
+    constructor(registerKind : RegisterKind, registerContent : string | vscode.Position | RectangleContent) {
+        this.kind = registerKind;
+        this.content = registerContent;
+    }
+
+    static fromRegion(registerContent : string) {
+        return new this(RegisterKind.KText, registerContent);
+    }
+
+    static fromPoint(registerContent : vscode.Position) {
+        return new this(RegisterKind.KPoint, registerContent);
+    } 
+
+    static fromRectangle(registerContent : RectangleContent) {
+        return new this(RegisterKind.KRectangle, registerContent);
+    } 
+
+    getRegisterKind() : RegisterKind {
+        return this.kind;
+    }
+
+    getRegisterContent() : string | vscode.Position | RectangleContent {
+        return this.content;
+    }
+};


### PR DESCRIPTION
Initial code for supporting "Registers" operation.
1. Capturing long (beyond 2 chords) keybinding in VSCode extension seems
to be somewhat non-trivial: do it via 'type' command using the very same
approach MS uses in its VIM example.
2. Implement basic support for Emacs registers (at this moment, only text/
region registers are supported).
3. Implement support for 'C-x r s' (save region to register) keybinding.
4. Implement support for 'C-x r i' (insert register content) keybinding.
