### PR TITLE
'C-g' should cancel long keybinding in progress (if any).

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -26,6 +26,12 @@ export class Editor {
         });
     }
 
+    onCancel() : void {
+        this.keybindProgressMode = KeybindProgressMode.None; // cancel long keybinding in progress (if any)
+        this.setStatusBarPermanentMessage("");
+        this.setStatusBarMessage("Quit");
+    }
+
     setStatusBarMessage(text: string): vscode.Disposable {
         return vscode.window.setStatusBarMessage(text, 1000);
     }

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -43,7 +43,7 @@ export class Operation {
                 this.editor.setStatusBarMessage("Undo!");
             },
             'C-g': () => {
-                this.editor.setStatusBarMessage("Quit");
+                this.editor.onCancel();
             },
             "C-x_r": () => {
                 this.editor.setRMode();


### PR DESCRIPTION
Quick fix for issue #30.
Known issues:
1. Generally, 'Ctrl+g' should be pressed twice. This is connected with curios
current behavior [of vscode-emacs extension]: whenever there is an active 
selection, pressing 'Ctrl+g' for the first time clears up the selection, but 
extension does not receive neither 'C-g', nor 'Type' command. Pressing 'Ctrl+g'
for the second time results in [extension] receiving 'C-g' command.
2. Unlike Emacs, extension does not preserve current selection on pressing 'Ctrl+g'.
TODO:
Investigate the situation with 'C-g' behavior in more details. 