### PR TITLE
Add support for a part of case conversion commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Use `Shift+Insert` to paste from clipboard.
 | `C-x u` (`C-/`)| OK | Undo |
 | `C-;` | △ | Toggle line comment in and out |
 | `M-;` | △ | Toggle region comment in and out |
+| `C-x C-l` | OK | Convert to lower case |
+| `C-x C-u` | OK | Convert to upper case |
 
 ### Other Command
 |Command | Status | Desc |

--- a/package.json
+++ b/package.json
@@ -340,6 +340,14 @@
         "key": "ctrl+x r",
         "command": "emacs.C-x_r",
         "when": "editorTextFocus"
+      },{
+        "key": "ctrl+x ctrl+l",
+        "command": "editor.action.transformToLowercase",
+        "when": "editorTextFocus && !editorReadonly"
+      },{
+        "key": "ctrl+x ctrl+u",
+        "command": "editor.action.transformToUppercase",
+        "when": "editorTextFocus && !editorReadonly"
       }
     ]
   },


### PR DESCRIPTION
Add support for `downcase-region` and `upcase-region` in https://www.gnu.org/software/emacs/manual/html_node/emacs/Case.html