### PR TITLE
add emacs yank-pop M-y functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -340,6 +340,10 @@
         "key": "ctrl+x r",
         "command": "emacs.C-x_r",
         "when": "editorTextFocus"
+      },{
+        "key": "alt+y",
+        "command": "emacs.yank-pop",
+        "when": "editorTextFocus"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -344,6 +344,10 @@
         "key": "alt+y",
         "command": "emacs.M-y",
         "when": "editorTextFocus"
+      },{
+        "key": "backspace",
+        "command": "emacs.backspace",
+        "when": "editorTextFocus"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -342,7 +342,7 @@
         "when": "editorTextFocus"
       },{
         "key": "alt+y",
-        "command": "emacs.yank-pop",
+        "command": "emacs.M-y",
         "when": "editorTextFocus"
       }
     ]

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -15,7 +15,7 @@ export class Editor {
     private ringIndex: number;
     private keybindProgressMode: KeybindProgressMode;
     private registersStorage: { [key:string] : RegisterContent; };
-    private yanked;
+    private yanked: boolean;
 
     constructor() {
         this.killRing = [];

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -88,12 +88,12 @@ export class Editor {
 
     private killText(range: vscode.Range): void {
         let text = vscode.window.activeTextEditor.document.getText(range);
-        this.killRing[this.ringIndex++] = text
+        this.killRing[this.ringIndex++] = text;
         //max 20 items in the ring to avoid excessice memory use
         //adjust if desired
         this.ringIndex = this.ringIndex % 20;
-        Editor.delete(range),
-        vscode.commands.executeCommand("emacs.exitMarkMode")
+        Editor.delete(range);
+        vscode.commands.executeCommand("emacs.exitMarkMode");
     }
 
     copy(range: vscode.Range = null): boolean {
@@ -319,7 +319,7 @@ export class Editor {
     }
 
     SaveTextToRegister(registerName: string): void {
-        if (null == registerName) {
+        if (null === registerName) {
             return;
         }
         let range : vscode.Range = this.getSelectionRange();
@@ -335,7 +335,7 @@ export class Editor {
     RestoreTextFromRegister(registerName: string): void {
         vscode.commands.executeCommand("emacs.exitMarkMode"); // emulate Emacs 
         let obj : RegisterContent = this.registersStorage[registerName];
-        if (null == obj) {
+        if (null === obj) {
             this.setStatusBarMessage("Register does not contain text.");
             return;
         }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -131,7 +131,6 @@ export class Editor {
         return true;
     }
     async yankPop(): Promise<boolean> {
-        console.log(this.yanked);
         if(!this.yanked) {
            return new Promise<boolean>((resolve) => {
                resolve(false);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
             // Edit
             "C-k", "C-w", "M-w", "C-y", "C-x_C-o",
-            "C-x_u", "C-/",
+            "C-x_u", "C-/", "M-y",
 
             // R-Mode
             "C-x_r"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
             // Edit
             "C-k", "C-w", "M-w", "C-y", "C-x_C-o",
-            "C-x_u", "C-/", "M-y",
+            "C-x_u", "C-/", "M-y", "backspace",
 
             // R-Mode
             "C-x_r"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,7 +37,6 @@ export function activate(context: vscode.ExtensionContext): void {
             })
         )
     });
-
     // 'type' is not an "emacs." command and should be registered separately
     context.subscriptions.push(vscode.commands.registerCommand("type", function (args) {
 		if (!vscode.window.activeTextEditor) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,7 +35,7 @@ export function activate(context: vscode.ExtensionContext): void {
                     element
                 );
             })
-        )
+        );
     });
     // 'type' is not an "emacs." command and should be registered separately
     context.subscriptions.push(vscode.commands.registerCommand("type", function (args) {
@@ -44,7 +44,6 @@ export function activate(context: vscode.ExtensionContext): void {
 		}
 		op.onType(args.text);        
     }));
-
     initMarkMode(context);
 }
 
@@ -54,9 +53,13 @@ export function deactivate(): void {
 function initMarkMode(context: vscode.ExtensionContext): void {
     context.subscriptions.push(vscode.commands.registerCommand(
         'emacs.enterMarkMode', () => {
-            initSelection();
-            inMarkMode = true;
-            vscode.window.setStatusBarMessage("Mark Set", 1000);
+            if(!inMarkMode) {
+                initSelection();
+                inMarkMode = true;
+                vscode.window.setStatusBarMessage("Mark Set", 1000);
+            } else {
+                vscode.commands.executeCommand("emacs.exitMarkMode");
+            }
         })
     );
 

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -1,5 +1,5 @@
 import {Editor} from './editor';
-
+import {commands} from 'vscode';
 export class Operation {
     private editor: Editor;
     private commandList: { [key: string]: (...args: any[]) => any, thisArgs?: any } = {};
@@ -59,6 +59,10 @@ export class Operation {
                 }).catch(function(error) {
                     console.log(error);
                 });
+            },
+            "backspace": () => {
+                commands.executeCommand("deleteLeft");
+                commands.executeCommand("cancelSelection");
             }
         };
     }

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -49,11 +49,16 @@ export class Operation {
                 this.editor.setRMode();
             },
             "M-y": () => {
-                if(this.editor.yankPop()) {
-                    this.editor.setStatusBarMessage("Yank Pop");    
-                } else {
-                    this.editor.setStatusBarMessage("Previous command was not a yank");
-                }                
+                let that = this;
+                this.editor.yankPop().then(function(result) {
+                    if (result) {
+                        that.editor.setStatusBarMessage("Yank Pop");
+                    } else {
+                        that.editor.setStatusBarMessage("Previous command was not a yank");
+                    }
+                }).catch(function(error) {
+                    console.log(error);
+                });
             }
         };
     }

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -48,6 +48,13 @@ export class Operation {
             "C-x_r": () => {
                 this.editor.setRMode();
             },
+            "M-y": () => {
+                if(this.editor.yankPop()) {
+                    this.editor.setStatusBarMessage("Yank Pop");    
+                } else {
+                    this.editor.setStatusBarMessage("Previous command was not a yank");
+                }                
+            }
         };
     }
 

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -61,8 +61,9 @@ export class Operation {
                 });
             },
             "backspace": () => {
-                commands.executeCommand("deleteLeft");
-                commands.executeCommand("cancelSelection");
+                commands.executeCommand("deleteLeft").then(() => {
+                    commands.executeCommand("emacs.exitMarkMode");
+                });
             }
         };
     }


### PR DESCRIPTION
Hi, I've added the ability to circle through killed text as used in the emacs yank-pop command (M-y) since I believe this makes the plug in a lot more useful.
Also, I slightly modified the vscode backspace key so that it also cancels selection in addition to deleting the selected text (as it works in emacs).
I've allowed for a maximum of 20 items in the kill ring to avoid using too much memory. Feel free to change this to whatever you prefer.